### PR TITLE
Add instruction issue authoring commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ What is implemented as tested packages but not yet wired into a full autonomous 
 ```bash
 sg version
 sg init
+sg issue draft <repository> --from-file task.md
+sg issue create <repository> --from-file task.md
 sg enqueue <repository> <issue-number> --config /path/to/config.yaml
 sg doctor --config /path/to/config.yaml
 sg serve --config /path/to/config.yaml
@@ -38,9 +40,11 @@ sg resume <task-id> --config /path/to/config.yaml
 Notes:
 
 - `sg init` interactively creates a config file with project-local or system-wide defaults
+- `sg issue draft/create` renders or creates a task-instruction GitHub Issue from a markdown source file
 - `sg enqueue <repository> <issue-number>` registers a queued task through the daemon control API
 - `sg serve` runs in the foreground until it receives `SIGINT` or `SIGTERM`
 - `sg status` and task actions talk to the daemon over the configured Unix socket
+- `sg issue create` requires the GitHub CLI (`gh`) to be installed and authenticated
 
 ## Runtime architecture
 
@@ -137,6 +141,19 @@ Query it from another terminal:
 ./bin/sg enqueue soudai/saga 123 --config ./sg.local.yaml
 ./bin/sg doctor --config ./sg.local.yaml
 ./bin/sg status --config ./sg.local.yaml
+```
+
+To create a task-instruction issue on GitHub from a local markdown brief:
+
+```bash
+cat > task.md <<'EOF'
+Implement the enqueue flow for GitHub issues.
+EOF
+
+gh auth login
+./bin/sg issue draft soudai/saga --from-file task.md
+./bin/sg issue create soudai/saga --from-file task.md
+./bin/sg issue create soudai/saga --from-file task.md --enqueue --config ./sg.local.yaml
 ```
 
 ## Implemented building blocks

--- a/README_ja.md
+++ b/README_ja.md
@@ -26,6 +26,8 @@ Saga は、Linux / WSL2 上でローカル常駐 orchestration を行う Go 製 
 ```bash
 sg version
 sg init
+sg issue draft <repository> --from-file task.md
+sg issue create <repository> --from-file task.md
 sg enqueue <repository> <issue-number> --config /path/to/config.yaml
 sg doctor --config /path/to/config.yaml
 sg serve --config /path/to/config.yaml
@@ -38,9 +40,11 @@ sg resume <task-id> --config /path/to/config.yaml
 補足:
 
 - `sg init` は対話形式で config file を生成し、project-local / system-wide の初期値を選べます
+- `sg issue draft/create` は markdown の指示書ソースから task 用 GitHub Issue を下書きまたは作成します
 - `sg enqueue <repository> <issue-number>` は daemon の control API 経由で `queued` task を登録します
 - `sg serve` は `SIGINT` または `SIGTERM` を受けるまで foreground で動作します
 - `sg status` と task action は設定された Unix socket 経由で daemon に接続します
+- `sg issue create` を使うには GitHub CLI (`gh`) の install と認証が必要です
 
 ## ランタイム構成
 
@@ -137,6 +141,19 @@ log:
 ./bin/sg enqueue soudai/saga 123 --config ./sg.local.yaml
 ./bin/sg doctor --config ./sg.local.yaml
 ./bin/sg status --config ./sg.local.yaml
+```
+
+ローカルの markdown から task 指示書 Issue を GitHub に作る例:
+
+```bash
+cat > task.md <<'EOF'
+GitHub Issue を enqueue できる flow を実装する。
+EOF
+
+gh auth login
+./bin/sg issue draft soudai/saga --from-file task.md
+./bin/sg issue create soudai/saga --from-file task.md
+./bin/sg issue create soudai/saga --from-file task.md --enqueue --config ./sg.local.yaml
 ```
 
 ## 実装済み building block

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@
   - 実装フェーズ、マイルストーン、完了条件
 - [systemd-wsl2.md](./systemd-wsl2.md)
   - WSL2/systemd 上での運用要件と unit 例
+- [exaple.md](./exaple.md)
+  - 実際のユースケース別サンプル手順とチュートリアル
 
 ## v1 スコープ要約
 
@@ -38,3 +40,4 @@
 4. [tech-stack.md](./tech-stack.md)
 5. [implementation-plan.md](./implementation-plan.md)
 6. [systemd-wsl2.md](./systemd-wsl2.md)
+7. [exaple.md](./exaple.md)

--- a/docs/exaple.md
+++ b/docs/exaple.md
@@ -1,0 +1,181 @@
+# Saga Usage Examples
+
+## 目的
+
+このドキュメントは、`sg` を実際に使うときの代表的なユースケースを、手順ベースでまとめたサンプル集です。  
+README よりも実行順と操作例に寄せてあります。
+
+## 前提
+
+- Linux または WSL2 上で作業している
+- `go`, `git`, `gh` が利用可能
+- `gh auth login` が必要なケースでは事前に認証済みである
+
+---
+
+## 1. 初回セットアップして daemon を起動する
+
+### 1-1. binary を build する
+
+```bash
+make build
+```
+
+### 1-2. config を生成する
+
+```bash
+./bin/sg init ./sg.local.yaml
+```
+
+対話で確認される主な値:
+
+- `runtime.state_dir`
+- `runtime.run_dir`
+- `runtime.log_dir`
+- `server.socket_path`
+- `log.level`
+
+### 1-3. daemon を起動する
+
+```bash
+./bin/sg serve --config ./sg.local.yaml
+```
+
+別ターミナルで疎通確認します。
+
+```bash
+./bin/sg doctor --config ./sg.local.yaml
+./bin/sg status --config ./sg.local.yaml
+```
+
+期待結果:
+
+- `doctor` が path 周りのチェック結果を返す
+- `status` が `tasks=0 active_runs=0` などの現在状態を返す
+
+---
+
+## 2. 既存の GitHub Issue を local task として登録する
+
+対象 Issue が既に GitHub 上にある場合は、issue number を指定して queue に入れます。
+
+```bash
+./bin/sg enqueue soudai/saga 123 --config ./sg.local.yaml
+```
+
+確認:
+
+```bash
+./bin/sg status --config ./sg.local.yaml
+```
+
+期待結果:
+
+- `task id=... repo=soudai/saga issue=123 state=queued` が見える
+
+使いどころ:
+
+- 既存 repository の Issue を `sg` に取り込む
+- daemon/control plane までの接続を最小経路で確認する
+
+---
+
+## 3. markdown から「タスク指示書 Issue」を作成する
+
+短いメモや要件整理を、GitHub 上の task-instruction Issue に変換したい場合の例です。
+
+### 3-1. brief を markdown で用意する
+
+```bash
+cat > task.md <<'EOF'
+Implement the enqueue flow for GitHub issues.
+EOF
+```
+
+### 3-2. GitHub に送る前に body を確認する
+
+```bash
+./bin/sg issue draft soudai/saga --from-file task.md
+```
+
+このコマンドは次を自動で補います。
+
+- 先頭見出しが無ければ title を推定して H1 を付ける
+- `Background / Goal`, `Scope`, `Acceptance Criteria` を持つ最小テンプレートを作る
+- `sg` 生成の marker comment を先頭に付与する
+
+### 3-3. GitHub Issue を作成する
+
+```bash
+./bin/sg issue create soudai/saga --from-file task.md
+```
+
+期待結果:
+
+- `issue #<number> https://github.com/...` が出力される
+
+### 3-4. 作成した Issue をそのまま local task に登録する
+
+```bash
+./bin/sg issue create soudai/saga --from-file task.md --enqueue --config ./sg.local.yaml
+```
+
+期待結果:
+
+- Issue 作成結果
+- 続けて `task id=... repo=... issue=... state=queued`
+
+使いどころ:
+
+- 実装の指示書を先に GitHub に残したい
+- `repository + issue number` ベースの既存 task model を崩さずに投入したい
+
+---
+
+## 4. task の状態を確認・操作する
+
+現在の local task 一覧を確認します。
+
+```bash
+./bin/sg status --config ./sg.local.yaml
+```
+
+task id を指定して状態を操作できます。
+
+```bash
+./bin/sg cancel 1 --config ./sg.local.yaml
+./bin/sg retry 1 --config ./sg.local.yaml
+./bin/sg resume 1 --config ./sg.local.yaml
+```
+
+想定用途:
+
+- `cancel`: 実行を止めたい
+- `retry`: `queued` に戻したい
+- `resume`: `running` として再開扱いにしたい
+
+---
+
+## 5. WSL2 + systemd で常駐させる
+
+systemd 配下で運用したい場合は、次のドキュメントを参照してください。
+
+- [`systemd-wsl2.md`](./systemd-wsl2.md)
+- [`testing/smoke-test.md`](./testing/smoke-test.md)
+- [`../contrib/systemd/sg.service`](../contrib/systemd/sg.service)
+
+最小確認:
+
+```bash
+systemctl start sg
+systemctl status sg
+journalctl -u sg -f
+```
+
+---
+
+## 現時点の注意
+
+- `sg issue create` は GitHub CLI (`gh`) の install と認証が必要
+- 現在の `sg` は local control plane と task 登録までは end-to-end だが、daemon が自律的に GitHub Issue を取り込み続ける loop はまだ完全接続されていない
+- `sg issue create` の初版は `--from-file` 前提で、AI 対話による指示書生成はまだ含まない

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -44,12 +44,12 @@ func newIssueCommandWithDeps(stdin io.Reader, stdout io.Writer, configPath *stri
 		Use:   "issue",
 		Short: "Render or create instruction issues",
 	}
-	cmd.AddCommand(newIssueDraftCommand(stdin, stdout, deps))
+	cmd.AddCommand(newIssueDraftCommand(stdin, stdout))
 	cmd.AddCommand(newIssueCreateCommand(stdin, stdout, configPath, deps))
 	return cmd
 }
 
-func newIssueDraftCommand(stdin io.Reader, stdout io.Writer, deps issueCommandDeps) *cobra.Command {
+func newIssueDraftCommand(stdin io.Reader, stdout io.Writer) *cobra.Command {
 	var fromFile string
 	var title string
 

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/soudai/saga/internal/config"
+	"github.com/soudai/saga/internal/control"
+	sagagithub "github.com/soudai/saga/internal/github"
+	"github.com/soudai/saga/internal/instructionissue"
+)
+
+type issueEnqueueFunc func(ctx context.Context, configPath, repository string, issueNumber int64) (control.TaskResponse, error)
+
+type issueCommandDeps struct {
+	writer  sagagithub.IssueWriter
+	enqueue issueEnqueueFunc
+}
+
+func defaultIssueCommandDeps() issueCommandDeps {
+	return issueCommandDeps{
+		writer: sagagithub.NewGHCLIIssueWriter(),
+		enqueue: func(ctx context.Context, configPath, repository string, issueNumber int64) (control.TaskResponse, error) {
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return control.TaskResponse{}, err
+			}
+			return control.NewClient(cfg.Server.SocketPath).Enqueue(ctx, repository, issueNumber)
+		},
+	}
+}
+
+func newIssueCommand(stdin io.Reader, stdout io.Writer, configPath *string) *cobra.Command {
+	return newIssueCommandWithDeps(stdin, stdout, configPath, defaultIssueCommandDeps())
+}
+
+func newIssueCommandWithDeps(stdin io.Reader, stdout io.Writer, configPath *string, deps issueCommandDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Render or create instruction issues",
+	}
+	cmd.AddCommand(newIssueDraftCommand(stdin, stdout, deps))
+	cmd.AddCommand(newIssueCreateCommand(stdin, stdout, configPath, deps))
+	return cmd
+}
+
+func newIssueDraftCommand(stdin io.Reader, stdout io.Writer, deps issueCommandDeps) *cobra.Command {
+	var fromFile string
+	var title string
+
+	cmd := &cobra.Command{
+		Use:   "draft <repository>",
+		Short: "Render an instruction issue body locally",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repository, err := normalizeRepository(args[0])
+			if err != nil {
+				return err
+			}
+
+			content, err := readIssueSource(stdin, fromFile)
+			if err != nil {
+				return err
+			}
+
+			rendered, err := instructionissue.Render(content, instructionissue.RenderOptions{
+				Repository: repository,
+				Title:      title,
+			})
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(stdout, "%s\n", rendered.Body)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "path to the source markdown file ('-' to read from stdin)")
+	cmd.Flags().StringVar(&title, "title", "", "explicit issue title override")
+	return cmd
+}
+
+func newIssueCreateCommand(stdin io.Reader, stdout io.Writer, configPath *string, deps issueCommandDeps) *cobra.Command {
+	var fromFile string
+	var title string
+	var labels []string
+	var enqueue bool
+
+	cmd := &cobra.Command{
+		Use:   "create <repository>",
+		Short: "Create an instruction issue on GitHub",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repository, err := normalizeRepository(args[0])
+			if err != nil {
+				return err
+			}
+
+			content, err := readIssueSource(stdin, fromFile)
+			if err != nil {
+				return err
+			}
+
+			rendered, err := instructionissue.Render(content, instructionissue.RenderOptions{
+				Repository: repository,
+				Title:      title,
+			})
+			if err != nil {
+				return err
+			}
+
+			created, err := deps.writer.Create(cmd.Context(), repository, sagagithub.CreateIssueRequest{
+				Title:  rendered.Title,
+				Body:   rendered.Body,
+				Labels: labels,
+			})
+			if err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintf(stdout, "issue #%d %s\n", created.Number, created.URL); err != nil {
+				return err
+			}
+
+			if !enqueue {
+				return nil
+			}
+
+			task, err := deps.enqueue(cmd.Context(), *configPath, repository, created.Number)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(stdout, "task id=%d repo=%s issue=%d state=%s\n", task.ID, task.Repository, task.IssueNumber, task.State)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "path to the source markdown file ('-' to read from stdin)")
+	cmd.Flags().StringVar(&title, "title", "", "explicit issue title override")
+	cmd.Flags().StringArrayVar(&labels, "label", nil, "issue label to apply (repeatable)")
+	cmd.Flags().BoolVar(&enqueue, "enqueue", false, "register the created issue as a queued local task")
+	return cmd
+}
+
+func normalizeRepository(value string) (string, error) {
+	repository := strings.TrimSpace(value)
+	parts := strings.Split(repository, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("repository must be in owner/repo format")
+	}
+	return repository, nil
+}
+
+func readIssueSource(stdin io.Reader, fromFile string) (string, error) {
+	if fromFile == "" {
+		return "", fmt.Errorf("--from-file is required")
+	}
+
+	var data []byte
+	var err error
+	if fromFile == "-" {
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(fromFile)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return "", fmt.Errorf("instruction issue content is required")
+	}
+	return content, nil
+}

--- a/internal/cli/issue_test.go
+++ b/internal/cli/issue_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/soudai/saga/internal/control"
+	sagagithub "github.com/soudai/saga/internal/github"
+	"github.com/soudai/saga/internal/store"
+)
+
+func TestIssueDraftRendersTemplate(t *testing.T) {
+	t.Parallel()
+
+	path := writeIssueSource(t, "Implement auth support")
+
+	var stdout bytes.Buffer
+	configPath := ""
+	cmd := newIssueCommandWithDeps(strings.NewReader(""), &stdout, &configPath, issueCommandDeps{})
+	cmd.SetArgs([]string{"draft", "soudai/saga", "--from-file", path})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"<!-- sg:instruction-issue v1 repo=soudai/saga -->",
+		"# Implement auth support",
+		"## Background / Goal",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestIssueCreateCanEnqueueCreatedIssue(t *testing.T) {
+	t.Parallel()
+
+	path := writeIssueSource(t, "# Implement auth\n\nDetails")
+
+	writer := &stubIssueWriter{
+		issue: sagagithub.CreatedIssue{
+			Number: 123,
+			URL:    "https://github.com/soudai/saga/issues/123",
+		},
+	}
+
+	var stdout bytes.Buffer
+	configPath := ""
+	cmd := newIssueCommandWithDeps(strings.NewReader(""), &stdout, &configPath, issueCommandDeps{
+		writer: writer,
+		enqueue: func(_ context.Context, configPath, repository string, issueNumber int64) (control.TaskResponse, error) {
+			return control.TaskResponse{
+				ID:          7,
+				Repository:  repository,
+				IssueNumber: issueNumber,
+				State:       store.TaskStateQueued,
+			}, nil
+		},
+	})
+	cmd.SetArgs([]string{"create", "soudai/saga", "--from-file", path, "--label", "saga:ready", "--enqueue"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if writer.repository != "soudai/saga" {
+		t.Fatalf("repository = %q, want %q", writer.repository, "soudai/saga")
+	}
+	if writer.request.Title != "Implement auth" {
+		t.Fatalf("title = %q, want %q", writer.request.Title, "Implement auth")
+	}
+	if len(writer.request.Labels) != 1 || writer.request.Labels[0] != "saga:ready" {
+		t.Fatalf("labels = %#v, want saga:ready", writer.request.Labels)
+	}
+
+	for _, want := range []string{
+		"issue #123 https://github.com/soudai/saga/issues/123",
+		"task id=7 repo=soudai/saga issue=123 state=queued",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestIssueCommandRejectsInvalidRepository(t *testing.T) {
+	t.Parallel()
+
+	path := writeIssueSource(t, "Implement auth support")
+
+	configPath := ""
+	cmd := newIssueCommandWithDeps(strings.NewReader(""), ioDiscard{}, &configPath, issueCommandDeps{})
+	cmd.SetArgs([]string{"draft", "invalid", "--from-file", path})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "owner/repo") {
+		t.Fatalf("Execute() error = %v, want owner/repo validation", err)
+	}
+}
+
+func writeIssueSource(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "task.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}
+
+type stubIssueWriter struct {
+	repository string
+	request    sagagithub.CreateIssueRequest
+	issue      sagagithub.CreatedIssue
+	err        error
+}
+
+func (s *stubIssueWriter) Create(_ context.Context, repository string, req sagagithub.CreateIssueRequest) (sagagithub.CreatedIssue, error) {
+	s.repository = repository
+	s.request = req
+	return s.issue, s.err
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/internal/cli/issue_test.go
+++ b/internal/cli/issue_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,7 +96,7 @@ func TestIssueCommandRejectsInvalidRepository(t *testing.T) {
 	path := writeIssueSource(t, "Implement auth support")
 
 	configPath := ""
-	cmd := newIssueCommandWithDeps(strings.NewReader(""), ioDiscard{}, &configPath, issueCommandDeps{})
+	cmd := newIssueCommandWithDeps(strings.NewReader(""), io.Discard, &configPath, issueCommandDeps{})
 	cmd.SetArgs([]string{"draft", "invalid", "--from-file", path})
 
 	err := cmd.Execute()
@@ -125,10 +126,4 @@ func (s *stubIssueWriter) Create(_ context.Context, repository string, req sagag
 	s.repository = repository
 	s.request = req
 	return s.issue, s.err
-}
-
-type ioDiscard struct{}
-
-func (ioDiscard) Write(p []byte) (int, error) {
-	return len(p), nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,6 +36,7 @@ func NewRootCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to config file")
 
 	cmd.AddCommand(newInitCommand(stdin, stdout))
+	cmd.AddCommand(newIssueCommand(stdin, stdout, &configPath))
 	cmd.AddCommand(newEnqueueCommand(stdout, &configPath))
 	cmd.AddCommand(newVersionCommand(stdout))
 	cmd.AddCommand(newDoctorCommand(stdout, stderr, &configPath))

--- a/internal/github/issue_writer.go
+++ b/internal/github/issue_writer.go
@@ -1,0 +1,116 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+)
+
+type CreateIssueRequest struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+type CreatedIssue struct {
+	Number int64
+	URL    string
+}
+
+type IssueWriter interface {
+	Create(ctx context.Context, repository string, req CreateIssueRequest) (CreatedIssue, error)
+}
+
+type commandRunner interface {
+	CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type execCommandRunner struct{}
+
+func (execCommandRunner) CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+type GHCLIIssueWriter struct {
+	runner commandRunner
+}
+
+func NewGHCLIIssueWriter() GHCLIIssueWriter {
+	return GHCLIIssueWriter{runner: execCommandRunner{}}
+}
+
+func (w GHCLIIssueWriter) Create(ctx context.Context, repository string, req CreateIssueRequest) (CreatedIssue, error) {
+	args := []string{
+		"issue",
+		"create",
+		"--repo", repository,
+		"--title", req.Title,
+		"--body", req.Body,
+	}
+	for _, label := range req.Labels {
+		if strings.TrimSpace(label) == "" {
+			continue
+		}
+		args = append(args, "--label", label)
+	}
+
+	output, err := w.runner.CombinedOutput(ctx, "gh", args...)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return CreatedIssue{}, fmt.Errorf("gh CLI not found; install GitHub CLI and run gh auth login")
+		}
+
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return CreatedIssue{}, fmt.Errorf("create issue via gh: %s", message)
+	}
+
+	issueURL, err := extractIssueURL(string(output))
+	if err != nil {
+		return CreatedIssue{}, err
+	}
+	number, err := parseIssueNumber(issueURL)
+	if err != nil {
+		return CreatedIssue{}, err
+	}
+
+	return CreatedIssue{
+		Number: number,
+		URL:    issueURL,
+	}, nil
+}
+
+func extractIssueURL(output string) (string, error) {
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if _, err := url.ParseRequestURI(line); err == nil {
+			return line, nil
+		}
+	}
+	return "", fmt.Errorf("extract issue url: no URL found in gh output")
+}
+
+func parseIssueNumber(issueURL string) (int64, error) {
+	parsed, err := url.Parse(issueURL)
+	if err != nil {
+		return 0, fmt.Errorf("parse issue url: %w", err)
+	}
+
+	number, err := strconv.ParseInt(path.Base(parsed.Path), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse issue number: %w", err)
+	}
+	return number, nil
+}

--- a/internal/github/issue_writer_test.go
+++ b/internal/github/issue_writer_test.go
@@ -1,0 +1,74 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestGHCLIIssueWriterCreate(t *testing.T) {
+	t.Parallel()
+
+	runner := &stubCommandRunner{
+		output: []byte("https://github.com/soudai/saga/issues/123\n"),
+	}
+	writer := GHCLIIssueWriter{runner: runner}
+
+	issue, err := writer.Create(context.Background(), "soudai/saga", CreateIssueRequest{
+		Title:  "Implement auth",
+		Body:   "# Implement auth",
+		Labels: []string{"saga:ready", "backend"},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if issue.Number != 123 {
+		t.Fatalf("number = %d, want 123", issue.Number)
+	}
+	if issue.URL != "https://github.com/soudai/saga/issues/123" {
+		t.Fatalf("url = %q, want issue URL", issue.URL)
+	}
+
+	wantArgs := []string{
+		"issue", "create",
+		"--repo", "soudai/saga",
+		"--title", "Implement auth",
+		"--body", "# Implement auth",
+		"--label", "saga:ready",
+		"--label", "backend",
+	}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", runner.args, wantArgs)
+	}
+}
+
+func TestGHCLIIssueWriterCreateReturnsHelpfulError(t *testing.T) {
+	t.Parallel()
+
+	runner := &stubCommandRunner{
+		output: []byte("authentication failed"),
+		err:    errors.New("exit status 1"),
+	}
+	writer := GHCLIIssueWriter{runner: runner}
+
+	_, err := writer.Create(context.Background(), "soudai/saga", CreateIssueRequest{
+		Title: "Implement auth",
+		Body:  "# Implement auth",
+	})
+	if err == nil || err.Error() != "create issue via gh: authentication failed" {
+		t.Fatalf("Create() error = %v, want gh output in error", err)
+	}
+}
+
+type stubCommandRunner struct {
+	args   []string
+	output []byte
+	err    error
+}
+
+func (s *stubCommandRunner) CombinedOutput(_ context.Context, _ string, args ...string) ([]byte, error) {
+	s.args = append([]string(nil), args...)
+	return s.output, s.err
+}

--- a/internal/instructionissue/render.go
+++ b/internal/instructionissue/render.go
@@ -9,6 +9,7 @@ import (
 const markerPrefix = "<!-- sg:instruction-issue"
 
 var markdownHeadingPattern = regexp.MustCompile(`^#{1,3}\s+\S`)
+var markdownHeadingCapturePattern = regexp.MustCompile(`^#{1,3}\s+(.+)$`)
 
 type RenderOptions struct {
 	Repository string
@@ -26,8 +27,8 @@ func ExtractTitle(content string) string {
 		if trimmed == "" {
 			continue
 		}
-		if markdownHeadingPattern.MatchString(trimmed) {
-			return strings.TrimSpace(strings.TrimLeft(trimmed, "# "))
+		if matches := markdownHeadingCapturePattern.FindStringSubmatch(trimmed); len(matches) == 2 {
+			return strings.TrimSpace(matches[1])
 		}
 		return trimmed
 	}

--- a/internal/instructionissue/render.go
+++ b/internal/instructionissue/render.go
@@ -1,0 +1,94 @@
+package instructionissue
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const markerPrefix = "<!-- sg:instruction-issue"
+
+var markdownHeadingPattern = regexp.MustCompile(`^#{1,3}\s+\S`)
+
+type RenderOptions struct {
+	Repository string
+	Title      string
+}
+
+type RenderedIssue struct {
+	Title string
+	Body  string
+}
+
+func ExtractTitle(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if markdownHeadingPattern.MatchString(trimmed) {
+			return strings.TrimSpace(strings.TrimLeft(trimmed, "# "))
+		}
+		return trimmed
+	}
+	return ""
+}
+
+func Render(content string, opts RenderOptions) (RenderedIssue, error) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return RenderedIssue{}, fmt.Errorf("instruction issue content is required")
+	}
+
+	title := strings.TrimSpace(opts.Title)
+	if title == "" {
+		title = ExtractTitle(trimmed)
+	}
+	if title == "" {
+		return RenderedIssue{}, fmt.Errorf("instruction issue title is required")
+	}
+
+	body := trimmed
+	if !hasMarkdownHeading(trimmed) {
+		body = fmt.Sprintf(`# %s
+
+## Background / Goal
+
+%s
+
+## Scope
+
+- Inspect the target repository and narrow the implementation scope to the actual code paths.
+
+## Acceptance Criteria
+
+- The requested change is implemented.
+- Relevant tests or validation steps are updated.
+`, title, trimmed)
+	}
+
+	if !strings.HasPrefix(body, markerPrefix) {
+		body = fmt.Sprintf("%s\n\n%s", buildMarker(opts.Repository), body)
+	}
+
+	return RenderedIssue{
+		Title: title,
+		Body:  body,
+	}, nil
+}
+
+func hasMarkdownHeading(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if markdownHeadingPattern.MatchString(strings.TrimSpace(line)) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildMarker(repository string) string {
+	if strings.TrimSpace(repository) == "" {
+		return "<!-- sg:instruction-issue v1 -->"
+	}
+	return fmt.Sprintf("<!-- sg:instruction-issue v1 repo=%s -->", repository)
+}

--- a/internal/instructionissue/render_test.go
+++ b/internal/instructionissue/render_test.go
@@ -1,0 +1,65 @@
+package instructionissue
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractTitlePrefersHeading(t *testing.T) {
+	t.Parallel()
+
+	got := ExtractTitle("\n# Implement auth\n\nDetails")
+	if got != "Implement auth" {
+		t.Fatalf("ExtractTitle() = %q, want %q", got, "Implement auth")
+	}
+}
+
+func TestExtractTitleFallsBackToFirstNonEmptyLine(t *testing.T) {
+	t.Parallel()
+
+	got := ExtractTitle("\nImplement auth\n\nMore details")
+	if got != "Implement auth" {
+		t.Fatalf("ExtractTitle() = %q, want %q", got, "Implement auth")
+	}
+}
+
+func TestRenderWrapsBriefInInstructionTemplate(t *testing.T) {
+	t.Parallel()
+
+	rendered, err := Render("Implement auth support", RenderOptions{Repository: "soudai/saga"})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"<!-- sg:instruction-issue v1 repo=soudai/saga -->",
+		"# Implement auth support",
+		"## Background / Goal",
+		"## Scope",
+		"## Acceptance Criteria",
+	} {
+		if !strings.Contains(rendered.Body, want) {
+			t.Fatalf("rendered body missing %q:\n%s", want, rendered.Body)
+		}
+	}
+	if rendered.Title != "Implement auth support" {
+		t.Fatalf("title = %q, want %q", rendered.Title, "Implement auth support")
+	}
+}
+
+func TestRenderPreservesExistingMarkdownHeading(t *testing.T) {
+	t.Parallel()
+
+	body := "# Task Instruction\n\n## Background\n\nDetails"
+	rendered, err := Render(body, RenderOptions{Repository: "soudai/saga"})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if strings.Count(rendered.Body, "# Task Instruction") != 1 {
+		t.Fatalf("rendered body duplicated heading:\n%s", rendered.Body)
+	}
+	if !strings.HasPrefix(rendered.Body, "<!-- sg:instruction-issue v1 repo=soudai/saga -->") {
+		t.Fatalf("rendered body missing marker:\n%s", rendered.Body)
+	}
+}

--- a/internal/instructionissue/render_test.go
+++ b/internal/instructionissue/render_test.go
@@ -23,6 +23,15 @@ func TestExtractTitleFallsBackToFirstNonEmptyLine(t *testing.T) {
 	}
 }
 
+func TestExtractTitlePreservesLeadingHashInHeadingText(t *testing.T) {
+	t.Parallel()
+
+	got := ExtractTitle("## #HashTagTitle")
+	if got != "#HashTagTitle" {
+		t.Fatalf("ExtractTitle() = %q, want %q", got, "#HashTagTitle")
+	}
+}
+
 func TestRenderWrapsBriefInInstructionTemplate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #36

## Summary
- add `sg issue draft` and `sg issue create` commands for task-instruction issues
- render markdown briefs into a structured instruction issue body with extracted title and marker
- create GitHub issues via `gh issue create` and optionally enqueue the created issue as a local task
- document the flow in the English and Japanese READMEs

## Testing
- mkdir -p .gocache && GOCACHE=$(pwd)/.gocache go mod tidy && GOCACHE=$(pwd)/.gocache make fmt && GOCACHE=$(pwd)/.gocache make test